### PR TITLE
Grab the glyph.name instead of group naming

### DIFF
--- a/Metrics/Show Kerning Pairs.py
+++ b/Metrics/Show Kerning Pairs.py
@@ -15,9 +15,11 @@ editString = u""""""
 
 def nameMaker(kernGlyph):
 	if kernGlyph[0] == "@":
-		return kernGlyph[7:]
+		for thisGlyph in Font.glyphs:
+			if thisGlyph.rightKerningKey == kernGlyph or thisGlyph.leftKerningKey == kernGlyph:
+				return thisGlyph.name
 	else:
-		return Font.glyphForId_(kernGlyph).name	
+		return Font.glyphForId_(kernGlyph).name
 
 for thisLayer in selectedLayers:
 	thisGlyph = thisLayer.parent
@@ -44,5 +46,4 @@ for thisLayer in selectedLayers:
 					editString += kernPair
 			except:
 				pass
-
 Font.newTab(editString)


### PR DESCRIPTION
I was having trouble with non typical naming patterns like 'lc_g' with the previous method.