### PR TITLE
Fix Round Kerning to 5.py

### DIFF
--- a/Spacing/Round Kerning to 5.py
+++ b/Spacing/Round Kerning to 5.py
@@ -21,12 +21,16 @@ for eachFontMaster in font.masters:
 	eachFontMasterId = eachFontMaster.id
 	to_be_removed = []
 
-	for first, seconds in dict( font.kerning[eachFontMasterId] ).items():
-		if not first.startswith('@'):
-			first = font.glyphForId_( first ).name
+	for first, seconds in dict(font.kerning[eachFontMasterId]).items():
+        if isinstance(first, str) and first.startswith('@'):
+            firstName = first
+        else:
+            firstName = font.glyphForId_(first).name
 		for second in seconds:
-			if not second.startswith('@'):
-				second = font.glyphForId_( second ).name
+			if isinstance(second, str) and second.startswith('@'):
+                secondName = second
+            else:
+                secondName = font.glyphForId_(second).name
 			# round towards 5
 			existingValue = font.kerningForPair( eachFontMasterId, first, second )
 			value = myround( existingValue, 5)
@@ -40,4 +44,4 @@ for eachFontMaster in font.masters:
 		font.removeKerningForPair( eachFontMasterId, first, second )
 		printString += "0\t%s: %s, %s, %s\n" % (eachFontMaster.name, first, second, existingValue) 
 
-print printString
+print (printString)


### PR DESCRIPTION
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
  File "Round Kerning to 5.py", line 43
    print printString
    ^^^^^^^^^^^^^^^^^

Traceback (most recent call last):
File "<macro panel>", line 17
File "_pythonify.py", line 17, in getattr
return getattr(self.pyobjc_object, attr)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: '__NSCFNumber' object has no attribute 'startswith'